### PR TITLE
Convert the install script to ansible role

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  lint:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "ansible>=2.9,<2.10" ansible-lint
+          mkdir ~/ansible-roles
+          ansible-galaxy install --roles-path ~/ansible-roles -r requirements.yml
+
+      - name: Lint with ansible-lint
+        run: |
+          # Check Ansible syntax and formatting rules
+          ansible-lint .

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-home-assistant-supervised-ansible
+home_assistant_supervised
 =========
 
-Install Home Assistant Supervised on Raspberry Pi 4 running Raspbian.
+Install Home Assistant Supervised on Raspberry Pi 4 running Debian 10 (buster).
 
 Requirements
 ------------

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+home-assistant-supervised-ansible
+=========
+
+Install Home Assistant Supervised on Raspberry Pi 4 running Raspbian.
+
+Requirements
+------------
+
+python3-apt
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+@jhampson-dbre

--- a/Vagrantfile.debian10
+++ b/Vagrantfile.debian10
@@ -1,0 +1,73 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "generic/debian10"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder ".", "/vagrant", type: "smb"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo apt-get update
+    sudo apt-get -y install python3-pip
+    pip3 install "ansible>=2.9,<2.10"
+    ansible-galaxy install --roles-path /etc/ansible/roles geerlingguy.docker
+  SHELL
+end

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+prefix: /usr
+sysconfdir: /etc
+data_share: "{{ prefix }}/share/hassio"
+config: "{{ sysconfdir }}/hassio.json"
+machine: raspberrypi4
+docker_repo: homeassistant
+hassio_docker: "{{ DOCKER_REPO }}/armv7-hassio-supervisor"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,11 @@
 ---
+install_home_assistant_supervised_ansible_requirements: true
 prefix: /usr
 sysconfdir: /etc
 data_share: "{{ prefix }}/share/hassio"
 config: "{{ sysconfdir }}/hassio.json"
-machine: raspberrypi4
+machine: raspberrypi4-64
 docker_repo: homeassistant
-hassio_docker: "{{ docker_repo }}/armv7-hassio-supervisor"
 binary_docker: /usr/bin/docker
 service_docker: "docker.service"
+docker_apt_arch: arm64

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,4 +5,6 @@ data_share: "{{ prefix }}/share/hassio"
 config: "{{ sysconfdir }}/hassio.json"
 machine: raspberrypi4
 docker_repo: homeassistant
-hassio_docker: "{{ DOCKER_REPO }}/armv7-hassio-supervisor"
+hassio_docker: "{{ docker_repo }}/armv7-hassio-supervisor"
+binary_docker: /usr/bin/docker
+service_docker: "docker.service"

--- a/files/NetworkManager.conf
+++ b/files/NetworkManager.conf
@@ -1,0 +1,11 @@
+[main]
+dns=default
+plugins=keyfile
+autoconnect-retries-default=0
+rc-manager=file
+
+[keyfile]
+unmanaged-devices=type:bridge;type:tun;type:veth
+
+[logging]
+backend=journal

--- a/files/docker_daemon.json
+++ b/files/docker_daemon.json
@@ -1,0 +1,4 @@
+{
+    "log-driver": "journald",
+    "storage-driver": "overlay2"
+}

--- a/files/ha
+++ b/files/ha
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2048,SC2086
+
+docker exec hassio_cli ha $*

--- a/files/interfaces
+++ b/files/interfaces
@@ -1,0 +1,4 @@
+source /etc/network/interfaces.d/*
+
+auto lo
+iface lo inet loopback

--- a/files/system-connection-default
+++ b/files/system-connection-default
@@ -1,0 +1,13 @@
+[connection]
+id=Supervisor default
+uuid=f35ac84e-420b-4003-a6d9-9700e8a32e54
+type=802-3-ethernet
+llmnr=2
+mdns=2
+
+[ipv4]
+method=auto
+
+[ipv6]
+addr-gen-mode=stable-privacy
+method=auto

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart docker
+  service:
+    name: docker
+    state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,7 +4,7 @@
     name: docker
     state: restarted
 
-- name: restart networkmanager 
+- name: restart networkmanager
   service:
     name: NetworkManager
     state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,3 +3,8 @@
   service:
     name: docker
     state: restarted
+
+- name: restart networkmanager 
+  service:
+    name: NetworkManager
+    state: restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,52 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: 
+  - geerlingguy.docker
+  

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,20 +1,13 @@
 galaxy_info:
-  author: your name
-  description: your role description
-  company: your company (optional)
+  author: Jared Hampson
+  description: Install Home Assistant Supervised
+  role_name: home_assistant_supervised
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
   # issue_tracker_url: http://example.com/issue/tracker
 
-  # Choose a valid license ID from https://spdx.org - some suggested licenses:
-  # - BSD-3-Clause (default)
-  # - MIT
-  # - GPL-2.0-or-later
-  # - GPL-3.0-only
-  # - Apache-2.0
-  # - CC-BY-4.0
-  license: license (GPL-2.0-or-later, MIT, etc)
+  license: MIT
 
   min_ansible_version: 2.9
 
@@ -27,26 +20,15 @@ galaxy_info:
   # To view available platforms and versions (or releases), visit:
   # https://galaxy.ansible.com/api/v1/platforms/
   #
-  # platforms:
-  # - name: Fedora
-  #   versions:
-  #   - all
-  #   - 25
-  # - name: SomePlatform
-  #   versions:
-  #   - all
-  #   - 1.0
-  #   - 7
-  #   - 99.99
+  platforms:
+    - name: Debian
+      versions:
+        - buster
 
-  galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
+  galaxy_tags:
+    - raspberrypi
+    - raspbian
+    - hassio
 
-dependencies: 
+dependencies:
   - geerlingguy.docker
-  

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,2 @@
+# from galaxy
+- src: geerlingguy.docker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,8 +10,8 @@
       - curl
       - dbus
     state: latest
-    update_cache: yes 
-    
+    update_cache: yes
+
 - name: Disable Modem Manager to prevent issues when using serial devices
   service:
     name: ModemManager
@@ -25,22 +25,22 @@
   notify:
     - restart docker
 
-- name: Fix kernel dmesg restriction 
+- name: Fix kernel dmesg restriction
   sysctl:
-    name: kernel.dmesg_restrict 
+    name: kernel.dmesg_restrict
     value: '0'
     sysctl_set: yes
     state: present
     reload: yes
 
-- name: Create config for NetworkManager   
+- name: Create config for NetworkManager
   copy:
-    src: "{{ networkmanager_file['source'] }}" 
-    dest: "{{ networkmanager_file['target'] }}" 
+    src: "{{ networkmanager_file['source'] }}"
+    dest: "{{ networkmanager_file['target'] }}"
   loop:
     - source: NetworkManager.conf
-      target: /etc/NetworkManager/NetworkManager.conf   
-    - source: system-connection-default 
+      target: /etc/NetworkManager/NetworkManager.conf
+    - source: system-connection-default
       target: /etc/NetworkManager/system-connections/default
   loop_control:
     loop_var: networkmanager_file
@@ -54,3 +54,32 @@
     dest: /etc/network/interfaces
   notify:
     - restart networkmanager
+
+- name: Init folders
+  file:
+    path: "{{ data_share }}"
+    state: directory
+
+- name: Write config
+  template:
+    src: hassio.j2
+    dest: "{{ config }}"
+    mode: '0644'
+
+- name: Ensure all changed service are restarted
+  meta: flush_handlers
+
+- name: Write config
+  template:
+    src: hassio.j2
+    dest: "{{ config }}"
+
+- name: Read version infos from web
+  uri:
+    body_format: json
+    url: https://version.home-assistant.io/stable.json
+  register: hassio_stable_out
+
+- name: Set hassio_version fact
+  set_fact:
+    hassio_version: "{{ hassio_stable_out['json']['supervisor'] }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -97,3 +97,19 @@
     # As 'latest' usually already is present, we need to enable overwriting of existing tags
     force_tag: yes
     source: local
+
+- name: Install supervisor startup script
+  template:
+    src: hassio-supervisor.j2
+    dest: "{{ prefix }}/sbin/hassio-supervisor"
+    mode: a+x
+
+- name: Install supervisor service file
+  template:
+    src: hassio-supervisor.service.j2
+    dest: "{{ sysconfdir }}/systemd/system/hassio-supervisor.service"
+
+- name: Enable supervisor service
+  service:
+    name: hassio-supervisor
+    enabled: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,3 +83,17 @@
 - name: Set hassio_version fact
   set_fact:
     hassio_version: "{{ hassio_stable_out['json']['supervisor'] }}"
+
+- name: Install supervisor Docker container
+  docker_image:
+    name: "{{ hassio_docker }}:{{ hassio_version }}"
+    source: pull
+    state: present
+
+- name: Add tag latest to supervisor image
+  docker_image:
+    name: "{{ hassio_docker }}:{{ hassio_version }}"
+    repository: "{{ hassio_docker }}:latest"
+    # As 'latest' usually already is present, we need to enable overwriting of existing tags
+    force_tag: yes
+    source: local

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,14 @@
 ---
+- name: Install role requirements
+  import_tasks: requirements.yml
+  when: install_home_assistant_supervised_ansible_requirements|bool
+
 - name: Install OS package prereqs
   apt:
     name:
       - systemd
       - network-manager
       - apparmor
-      - docker
       - jq
       - curl
       - dbus
@@ -17,6 +20,11 @@
     name: ModemManager
     enabled: no
     state: stopped
+
+- name: Create Docker config directory
+  file:
+    path: /etc/docker
+    state: directory
 
 - name: Set up docker config file
   copy:
@@ -44,7 +52,7 @@
       target: /etc/NetworkManager/system-connections/default
   loop_control:
     loop_var: networkmanager_file
-    label: "{{ networkmanager_file['source']"
+    label: "{{ networkmanager_file['source'] }}"
   notify:
     - restart networkmanager
 
@@ -86,14 +94,14 @@
 
 - name: Install supervisor Docker container
   docker_image:
-    name: "{{ hassio_docker }}:{{ hassio_version }}"
+    name: "{{ arch[ansible_architecture]['hassio_docker'] }}:{{ hassio_version }}"
     source: pull
     state: present
 
 - name: Add tag latest to supervisor image
   docker_image:
-    name: "{{ hassio_docker }}:{{ hassio_version }}"
-    repository: "{{ hassio_docker }}:latest"
+    name: "{{ arch[ansible_architecture]['hassio_docker'] }}:{{ hassio_version }}"
+    repository: "{{ arch[ansible_architecture]['hassio_docker'] }}:latest"
     # As 'latest' usually already is present, we need to enable overwriting of existing tags
     force_tag: yes
     source: local
@@ -113,47 +121,48 @@
   service:
     name: hassio-supervisor
     enabled: yes
-    
+
 - name: Create AppArmor directory
   file:
-    path: "{{ data_share }}/apparmor"  
+    path: "{{ data_share }}/apparmor"
     state: directory
-  
+
 - name: Install AppArmor startup script
-  src: hassio-apparmor.service.j2
-  dest: "{{ prefix }}/sbin/hassio-apparmor"
-  mode: a+x
+  template:
+    src: hassio-apparmor.j2
+    dest: "{{ prefix }}/sbin/hassio-apparmor"
+    mode: a+x
 
 - name: Install AppArmor service file
   template:
     src: hassio-apparmor.service.j2
     dest: "{{ sysconfdir }}/systemd/system/hassio-apparmor.service"
-  
-- name: Download AppArmor profile 
+
+- name: Download AppArmor profile
   get_url:
     url: https://version.home-assistant.io/apparmor.txt
     dest: "{{ data_share }}/apparmor/hassio-supervisor"
 
-- name: Enable and start AppArmor service 
+- name: Enable and start AppArmor service
   service:
-    name: hassio-apparmor 
+    name: hassio-apparmor
     enabled: yes
-    start: started
+    state: started
 
 # AppArmor service must be started before Home Assistant service
 - name: Start Home Assistant Supervised
   service:
-    name: hassio-supervisor 
-    start: started
+    name: hassio-supervisor
+    state: started
 
-- name: Install the 'ha' cli 
+- name: Install the 'ha' cli
   copy:
-    src: ha 
-    dest: "{{ prefix }}/bin/ha" 
+    src: ha
+    dest: "{{ prefix }}/bin/ha"
     mode: a+x
 
 - name: Home Assistant supervised is now installed
   debug:
-    msg:  
+    msg:
       - "First setup will take some time, when it's ready you can reach it here:"
       - "http://{{ ansible_default_ipv4['address'] }}:8123"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   import_tasks: requirements.yml
   when: install_home_assistant_supervised_ansible_requirements|bool
 
-- name: Install OS package prereqs
+- name: Install OS package prereqs # noqa 403
   apt:
     name:
       - systemd
@@ -25,11 +25,13 @@
   file:
     path: /etc/docker
     state: directory
+    mode: '0755'
 
 - name: Set up docker config file
   copy:
     src: docker_daemon.json
     dest: /etc/docker/daemon.json
+    mode: '0644'
   notify:
     - restart docker
 
@@ -45,6 +47,7 @@
   copy:
     src: "{{ networkmanager_file['source'] }}"
     dest: "{{ networkmanager_file['target'] }}"
+    mode: '0644'
   loop:
     - source: NetworkManager.conf
       target: /etc/NetworkManager/NetworkManager.conf
@@ -60,6 +63,7 @@
   copy:
     src: interfaces
     dest: /etc/network/interfaces
+    mode: '0644'
   notify:
     - restart networkmanager
 
@@ -67,6 +71,7 @@
   file:
     path: "{{ data_share }}"
     state: directory
+    mode: '0755'
 
 - name: Write config
   template:
@@ -81,6 +86,7 @@
   template:
     src: hassio.j2
     dest: "{{ config }}"
+    mode: '0644'
 
 - name: Read version infos from web
   uri:
@@ -116,6 +122,7 @@
   template:
     src: hassio-supervisor.service.j2
     dest: "{{ sysconfdir }}/systemd/system/hassio-supervisor.service"
+    mode: '0644'
 
 - name: Enable supervisor service
   service:
@@ -126,6 +133,7 @@
   file:
     path: "{{ data_share }}/apparmor"
     state: directory
+    mode: '0755'
 
 - name: Install AppArmor startup script
   template:
@@ -137,11 +145,13 @@
   template:
     src: hassio-apparmor.service.j2
     dest: "{{ sysconfdir }}/systemd/system/hassio-apparmor.service"
+    mode: '0644'
 
 - name: Download AppArmor profile
   get_url:
     url: https://version.home-assistant.io/apparmor.txt
     dest: "{{ data_share }}/apparmor/hassio-supervisor"
+    mode: '0644'
 
 - name: Enable and start AppArmor service
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,51 @@
+---
+- name: Install OS package prereqs
+  apt:
+    name:
+      - systemd
+      - network-manager
+      - apparmor
+      - docker
+      - jq
+      - curl
+      - dbus
+    state: latest
+    update_cache: yes 
+    
+- name: Disable Modem Manager to prevent issues when using serial devices
+  service:
+    name: ModemManager
+    enabled: no
+    state: stopped
+
+- name: Set up docker config file
+  copy:
+    src: docker_daemon.json
+    dest: /etc/docker/daemon.json
+  notify:
+    - restart docker
+
+- name: Fix kernel dmesg restriction 
+  sysctl:
+    name: kernel.dmesg_restrict 
+    value: '0'
+    sysctl_set: yes
+    state: present
+    reload: yes
+
+- name: Create config for NetworkManager   
+  copy:
+    src: "{{ networkmanager_file['source'] }}" 
+    dest: "{{ networkmanager_file['target'] }}" 
+  loop:
+    - source: NetworkManager.conf
+      target: /etc/NetworkManager/NetworkManager.conf   
+    - source: system-connection-default 
+      target: /etc/NetworkManager/system-connections/default
+  loop_control:
+    loop_var: networkmanager_file
+    label: "{{ networkmanager_file['source']"
+
+  
+  
+    

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -113,3 +113,35 @@
   service:
     name: hassio-supervisor
     enabled: yes
+    
+- name: Create AppArmor directory
+  file:
+    path: "{{ data_share }}/apparmor"  
+    state: directory
+  
+- name: Install AppArmor startup script
+  src: hassio-apparmor.service.j2
+  dest: "{{ prefix }}/sbin/hassio-apparmor"
+  mode: a+x
+
+- name: Install AppArmor service file
+  template:
+    src: hassio-apparmor.service.j2
+    dest: "{{ sysconfdir }}/systemd/system/hassio-apparmor.service"
+  
+- name: Download AppArmor profile 
+  get_url:
+    url: https://version.home-assistant.io/apparmor.txt
+    dest: "{{ data_share }}/apparmor/hassio-supervisor"
+
+- name: Enable and start AppArmor service 
+  service:
+    name: hassio-apparmor 
+    enabled: yes
+    start: started
+
+# AppArmor service must be started before Home Assistant service
+- name: Start Home Assistant Supervised
+  service:
+    name: hassio-supervisor 
+    start: started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -145,3 +145,15 @@
   service:
     name: hassio-supervisor 
     start: started
+
+- name: Install the 'ha' cli 
+  copy:
+    src: ha 
+    dest: "{{ prefix }}/bin/ha" 
+    mode: a+x
+
+- name: Home Assistant supervised is now installed
+  debug:
+    msg:  
+      - "First setup will take some time, when it's ready you can reach it here:"
+      - "http://{{ ansible_default_ipv4['address'] }}:8123"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,12 @@
   loop_control:
     loop_var: networkmanager_file
     label: "{{ networkmanager_file['source']"
+  notify:
+    - restart networkmanager
 
-  
-  
-    
+- name: Overwrite network interfaces file
+  copy:
+    src: interfaces
+    dest: /etc/network/interfaces
+  notify:
+    - restart networkmanager

--- a/tasks/requirements.yml
+++ b/tasks/requirements.yml
@@ -2,6 +2,6 @@
 - name: Install pip requirements for home-assistant-supervised-ansible
   pip:
     name:
-      - docker 
+      - docker
     executable: pip3
     extra_args: --user

--- a/tasks/requirements.yml
+++ b/tasks/requirements.yml
@@ -1,0 +1,7 @@
+---
+- name: Install pip requirements for home-assistant-supervised-ansible
+  pip:
+    name:
+      - docker 
+    executable: pip3
+    extra_args: --user

--- a/templates/hassio-apparmor.j2
+++ b/templates/hassio-apparmor.j2
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -e
+
+# Load configs
+CONFIG_FILE={{ config }}
+
+# Read configs
+DATA="$(jq --raw-output '.data // "/usr/share/hassio"' ${CONFIG_FILE})"
+PROFILES_DIR="${DATA}/apparmor"
+CACHE_DIR="${PROFILES_DIR}/cache"
+REMOVE_DIR="${PROFILES_DIR}/remove"
+
+# Exists AppArmor
+if ! command -v apparmor_parser > /dev/null 2>&1; then
+    echo "[Warning]: No apparmor_parser on host system!"
+    exit 0
+fi
+
+# Check folder structure
+mkdir -p "${PROFILES_DIR}"
+mkdir -p "${CACHE_DIR}"
+mkdir -p "${REMOVE_DIR}"
+
+# Load/Update exists/new profiles
+for profile in "${PROFILES_DIR}"/*; do
+    if [ ! -f "${profile}" ]; then
+        continue
+    fi
+
+    # Load Profile
+    if ! apparmor_parser -r -W -L "${CACHE_DIR}" "${profile}"; then
+        echo "[Error]: Can't load profile ${profile}"
+    fi
+done
+
+# Cleanup old profiles
+for profile in "${REMOVE_DIR}"/*; do
+    if [ ! -f "${profile}" ]; then
+        continue
+    fi
+
+    # Unload Profile
+    if apparmor_parser -R -W -L "${CACHE_DIR}" "${profile}"; then
+        if rm -f "${profile}"; then
+            continue
+        fi
+    fi
+    echo "[Error]: Can't remove profile ${profile}"
+done

--- a/templates/hassio-apparmor.service.j2
+++ b/templates/hassio-apparmor.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Hass.io AppArmor
+Wants=hassio-supervisor.service
+Before={{ service_docker }} hassio-supervisor.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart={{ prefix }}/sbin/hassio-apparmor
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/hassio-supervisor.j2
+++ b/templates/hassio-supervisor.j2
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -e
+
+# Load configs
+CONFIG_FILE={{ config }}
+
+SUPERVISOR="$(jq --raw-output '.supervisor' ${CONFIG_FILE})"
+MACHINE="$(jq --raw-output '.machine' ${CONFIG_FILE})"
+DATA="$(jq --raw-output '.data // "/usr/share/hassio"' ${CONFIG_FILE})"
+
+# Init supervisor
+HASSIO_DATA=${DATA}
+HASSIO_IMAGE_ID=$(docker inspect --format='{{ '{{.Id}}' }}' "${SUPERVISOR}")
+HASSIO_CONTAINER_ID=$(docker inspect --format='{{ '{{.Image}}' }}' hassio_supervisor || echo "")
+
+runSupervisor() {
+    docker rm --force hassio_supervisor || true
+
+    # shellcheck disable=SC2086
+    docker run --name hassio_supervisor \
+        --privileged \
+        --security-opt apparmor=hassio-supervisor \
+        --security-opt seccomp=unconfined \
+        -v /run/docker.sock:/run/docker.sock \
+        -v /run/dbus:/run/dbus \
+        -v /etc/machine-id:/etc/machine-id:ro \
+        -v "${HASSIO_DATA}":/data:rw \
+        -e SUPERVISOR_SHARE="${HASSIO_DATA}" \
+        -e SUPERVISOR_NAME=hassio_supervisor \
+        -e SUPERVISOR_MACHINE="${MACHINE}" \
+        "${SUPERVISOR}"
+}
+
+# Run supervisor
+mkdir -p "${HASSIO_DATA}"
+([ "${HASSIO_IMAGE_ID}" = "${HASSIO_CONTAINER_ID}" ] && docker start --attach hassio_supervisor) || runSupervisor

--- a/templates/hassio-supervisor.service.j2
+++ b/templates/hassio-supervisor.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Hass.io supervisor
+Requires={{ service_docker }}
+After={{ service_docker }} dbus.socket
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=5s
+ExecStartPre=-{{ binary_docker }} stop hassio_supervisor
+ExecStart={{ prefix }}/sbin/hassio-supervisor
+ExecStop=-{{ binary_docker }} stop hassio_supervisor
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/hassio.j2
+++ b/templates/hassio.j2
@@ -1,0 +1,5 @@
+{
+    "supervisor": "{{ hassio_docker }}",
+    "machine": "{{ machine }}",
+    "data": "{{ data_share }}"
+}

--- a/templates/hassio.j2
+++ b/templates/hassio.j2
@@ -1,5 +1,5 @@
 {
-    "supervisor": "{{ hassio_docker }}",
+    "supervisor": "{{ arch[ansible_architecture]['hassio_docker'] }}",
     "machine": "{{ machine }}",
     "data": "{{ data_share }}"
 }

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,1 @@
+localhost ansible_python_interpreter=/usr/bin/python3

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,9 @@
+---
+- hosts: localhost
+  become: yes
+  force_handlers: true
+  roles:
+    - role: home-assistant-supervised-ansible
+      vars:
+        machine: qemux86-64 
+        docker_apt_arch: amd64

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -5,5 +5,5 @@
   roles:
     - role: home-assistant-supervised-ansible
       vars:
-        machine: qemux86-64 
+        machine: qemux86-64
         docker_apt_arch: amd64

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,16 @@
+---
+arch:
+  "i386":
+    hassio_docker: "{{ docker_repo }}/i386-hassio-supervisor"
+  "i686":
+    hassio_docker: "{{ docker_repo }}/i386-hassio-supervisor"
+  "x86_64":
+    hassio_docker: "{{ docker_repo }}/amd64-hassio-supervisor"
+  "arm":
+    hassio_docker: "{{ docker_repo }}/armhf-hassio-supervisor"
+  "armv6l":
+    hassio_docker: "{{ docker_repo }}/armhf-hassio-supervisor"
+  "armv7l":
+    hassio_docker: "{{ docker_repo }}/armv7-hassio-supervisor"
+  "aarch64":
+    hassio_docker: "{{ docker_repo }}/aarch64-hassio-supervisor"


### PR DESCRIPTION
Home Assistant comes with an install script, but it is hard to to read, and possibly incomplete. This attempts to faithfully recreate to install script referenced in #1 with the following exceptions:
- where testing on Debian 10 VM seemed to indicate the the install script did not function as intended (e.g. installing docker daemon)
- Installation of dependencies required for the role to run, which can optionally be disabled, which would require the dependencies to be installed outside of the role

Planned enhancements that are outside the scope of this pull request to perform optional setup steps and security hardening, but those are not included in the install.sh script.